### PR TITLE
Updated AMLD 2018 link so that it goes to the listing of this talk in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Machine Learning with Go - AMLD 2018
 
-This repo includes all of the materials that you will need for the "Machine Learning with Go" workshop at [Applied ML Days](https://www.appliedmldays.org/) 2018.  This workshop will help attendees understand how Go can help them be productive and innovative in machine learning, and we will learn how to leverage Go to build robust and valuable applications. To this end, the workshop will clearly introduce the technical aspects of building predictive models in Go, but it will also help attendees understand how and why Go-based machine learning workflows are being applied in real-world scenarios.
+This repo includes all of the materials that you will need for the "Machine Learning with Go" workshop at [Applied ML Days 2018](https://www.appliedmldays.org/conf2018/workshop_sessions/machine-learning-with-go.1).  This workshop will help attendees understand how Go can help them be productive and innovative in machine learning, and we will learn how to leverage Go to build robust and valuable applications. To this end, the workshop will clearly introduce the technical aspects of building predictive models in Go, but it will also help attendees understand how and why Go-based machine learning workflows are being applied in real-world scenarios.
 
 ## Agenda
 


### PR DESCRIPTION
… the 2018 instead of the homepage of the conference, which gives you the most recent/upcoming edition of the conference. This is helpful for those who are finding this later.